### PR TITLE
Add git autosquash config

### DIFF
--- a/roles/git/templates/gitconfig.j2
+++ b/roles/git/templates/gitconfig.j2
@@ -79,3 +79,5 @@
 	st = status --short --branch
 [push]
 	default=current
+[rebase]
+	autosquash = true


### PR DESCRIPTION
> When the commit log message begins with "squash! ..." (or "fixup! ..."), and there is a commit whose title begins with the same ..., automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from pick to squash (or fixup).

You can use `git commit --fixup/--squash` to create a fixup/squash.